### PR TITLE
Some basic interface/code improvements

### DIFF
--- a/q2_aldex2/_method.py
+++ b/q2_aldex2/_method.py
@@ -1,12 +1,9 @@
 import os
 import qiime2
-import numpy as np
 import pandas as pd
-from biom import Table
 import tempfile
 import subprocess
 
-import q2_aldex2
 from q2_aldex2._visualizer import _effect_statistic_functions
 
 

--- a/q2_aldex2/_method.py
+++ b/q2_aldex2/_method.py
@@ -22,16 +22,18 @@ def run_commands(cmds, verbose=True):
 
 
 def aldex2(table: pd.DataFrame,
-           metadata: qiime2.Metadata,
-           condition: str,
+           metadata: qiime2.CategoricalMetadataColumn,
            mc_samples: int = 128,
            test: str = 't',
            denom: str = 'all') -> pd.DataFrame:
 
-    # create dataframe of the metadata
-    meta = metadata.to_dataframe()
+    # create series from the metadata column
+    meta = metadata.to_series()
 
-    # filter it so only the samples present in data are used
+    # The condition is just the only column in the passed metadata column
+    condition = metadata.name
+
+    # filter the metadata so only the samples present in the table are used
     # this also reorders it for the correct condition selection
     # it has to be re ordered for aldex to correctly input the conditions
     meta = meta.loc[list(table.index)]
@@ -43,8 +45,11 @@ def aldex2(table: pd.DataFrame,
         map_fp = os.path.join(temp_dir_name, 'input.map.txt')
         summary_fp = os.path.join(temp_dir_name, 'output.summary.txt')
 
-        table.to_csv(biom_fp, sep='\t')
-        meta.to_csv(map_fp, sep='\t')
+        # Need to manually specify header=True for Series (i.e. "meta"). It's
+        # already the default for DataFrames (i.e. "table"), but we manually
+        # specify it here anyway to alleviate any potential confusion.
+        table.to_csv(biom_fp, sep='\t', header=True)
+        meta.to_csv(map_fp, sep='\t', header=True)
 
         cmd = ['run_aldex2.R', biom_fp, map_fp, condition, mc_samples,
                test, denom, summary_fp]

--- a/q2_aldex2/_visualizer.py
+++ b/q2_aldex2/_visualizer.py
@@ -1,13 +1,8 @@
 import os
-import qiime2
-import numpy as np
 import pandas as pd
 import q2templates
 import pkg_resources
 import matplotlib.pyplot as plt
-from biom import Table
-import tempfile
-import subprocess
 
 
 TEMPLATES = pkg_resources.resource_filename('q2_aldex2', 'assets')

--- a/q2_aldex2/plugin_setup.py
+++ b/q2_aldex2/plugin_setup.py
@@ -1,7 +1,5 @@
-import qiime2
-from qiime2.plugin import (Str, Int, Float, Choices, Citations,
-                           Metadata, Categorical, Plugin)
-from q2_types.feature_table import FeatureTable, Frequency, Composition
+from qiime2.plugin import Str, Int, Float, Choices, Citations, Metadata, Plugin
+from q2_types.feature_table import FeatureTable, Frequency
 from q2_types.feature_data import FeatureData, Differential
 
 import q2_aldex2

--- a/q2_aldex2/plugin_setup.py
+++ b/q2_aldex2/plugin_setup.py
@@ -1,4 +1,6 @@
-from qiime2.plugin import Str, Int, Float, Choices, Citations, Metadata, Plugin
+from qiime2.plugin import (
+    Str, Int, Float, Choices, Citations, Plugin, MetadataColumn, Categorical
+)
 from q2_types.feature_table import FeatureTable, Frequency
 from q2_types.feature_data import FeatureData, Differential
 
@@ -26,27 +28,23 @@ plugin.methods.register_function(
     name=('Analysis Of Differential Abundance'),
     description=('Performs log-ratio transformation and statistical testing'),
     inputs={'table': FeatureTable[Frequency]},
-    # TODO: will need to provide restrictions on input parameters.
-    # see q2-composition for examples on how to do this
-    # https://github.com/qiime2/q2-composition/blob/master/q2_composition/plugin_setup.py#L48
-    parameters={'metadata': Metadata,
-                'condition': Str,
+    parameters={'metadata': MetadataColumn[Categorical],
                 'mc_samples': Int,
-                'test': Str,
-                'denom': Str},
+                'test': Str % Choices(['t', 'glm']),
+                'denom': Str % Choices(['all', 'iqlr'])},
     outputs=[('differentials', FeatureData[Differential])],
     input_descriptions={
-        'table': 'The feature table of abundances.'
+        'table': 'The feature table of abundances'
     },
     parameter_descriptions={
-        'metadata': 'Sample metadata',
-        'condition': 'Experimental descriptors to group samples',
+        'metadata': 'The "condition": this column will be used as an '
+                    'experimental descriptor to group samples',
         'mc_samples': 'The number of monte carlo samples to be used',
-        'test': 'The statistical test to run, options include `t`, or `glm`',
-        'denom': 'The features used to decide a reference frame.'
+        'test': 'The statistical test to run',
+        'denom': 'The features used to decide a reference frame'
     },
     output_descriptions={
-        'differentials': 'The estimated per-feature differentials.'
+        'differentials': 'The estimated per-feature differentials'
     }
 )
 
@@ -59,11 +57,12 @@ plugin.methods.register_function(
     description=('Extracts differentially expressed features from the'
                 'aldex2 differentials output'),
     inputs={'table': FeatureData[Differential]},
-    parameters={'sig_threshold': Float,
-            'effect_threshold': Float,
-            'difference_threshold': Float,
-            'test': Str % Choices(effect_statistic_methods)
-            },
+    parameters={
+        'sig_threshold': Float,
+        'effect_threshold': Float,
+        'difference_threshold': Float,
+        'test': Str % Choices(effect_statistic_methods)
+    },
     input_descriptions={
         'table': 'Output from aldex2 calculations'
     },
@@ -90,10 +89,10 @@ plugin.visualizers.register_function(
     },
     parameter_descriptions={
         'threshold': 'Statistical significance cutoff',
-        'test': 'Method of calculating significance, options include '
-        '`welch` for Welchs T test or `wilcox` for Wilcox rank test.'
+        'test': 'Method of calculating significance; options include '
+        "`welch` for Welch's T test or `wilcox` for Wilcox rank test"
     },
     name='Effect plots',
     description=('Visually explore the relationship between difference'
-                'between groups and within groups')
+                 'between groups and within groups')
 )

--- a/q2_aldex2/tests/test_method.py
+++ b/q2_aldex2/tests/test_method.py
@@ -125,15 +125,22 @@ class TestAldex2(unittest.TestCase):
         metadata.index.name = 'sampleid'
 
         table = rel_table
-        metadata = qiime2.Metadata(metadata)
         condition = 'labels'
+        # Make sure that pandas treats the condition column as categorical, and
+        # not numeric (since the "labels" are just ints, pandas infers this as
+        # a numeric column) -- solution from
+        # https://stackoverflow.com/a/22006514/10730311
+        metadata[condition] = metadata[condition].astype(str)
+        # metadata[condition] is just a pandas Series, which we can use to
+        # create a qiime2.CategoricalMetadataColumn -- solution from
+        # https://github.com/qiime2/q2-composition/blob/master/q2_composition/tests/test_ancom.py#L34
+        metadata = qiime2.CategoricalMetadataColumn(metadata[condition])
         mc_samples = 128
         test = 't'
         denom = 'all'
 
         # TODO : allow for summary type
-        diff = aldex2(table, metadata,
-                      condition, mc_samples, test, denom)
+        diff = aldex2(table, metadata, mc_samples, test, denom)
 
         res = pearsonr(diff.values.ravel(),
                        ground_truth.categorical.values.ravel())

--- a/q2_aldex2/tests/test_method.py
+++ b/q2_aldex2/tests/test_method.py
@@ -1,10 +1,7 @@
 import qiime2
 import numpy as np
 import pandas as pd
-import matplotlib.pyplot as plt
 from sklearn.utils import check_random_state
-from biom.util import biom_open
-from biom import Table
 from scipy.stats import pearsonr
 import unittest
 from q2_aldex2._method import aldex2

--- a/tutorial.md
+++ b/tutorial.md
@@ -15,7 +15,7 @@ qiime feature-table filter-samples \
 The next step will be to run ALDEx2. The full pipeline is implemented in the `aldex2` function The input is the `FeatureTable[Frequency]`, as well as a metadata file. The metadata file is necessary for defining the different groups you will be testing. For this tutorial, the groups are identified by the subject column from the metadata file. ALDEx2 automatically adds a prior [(see Results here for more technical details of the prior)](https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0067019) to remove zeros from the data, and filters any samples with 0 reads.
 
 ```
-qiime aldex2 aldex2 --i-table gut-table.qza --m-metadata-file sample-metadata.tsv --p-condition subject --output-dir gut-test
+qiime aldex2 aldex2 --i-table gut-table.qza --m-metadata-file sample-metadata.tsv --m-metadata-column subject --output-dir gut-test
 ```
 
 The output artifact is `differentials.qza`, which contains a summary of the ALDEx2 output (difference, dispersion, effect, q-score, etc). From this artifact, we can visualize and extract the differentially abundant features. It is important to visualize the size of the difference between conditions (difference) as well as the size of the difference within conditions (dispersion) to capture the full context of the within-group variation. One feature may appear as differentially expressed if it has a very small dispersion and slightly larger difference, while another may have a large difference, but an even larger dispersion. These are both cases where caution should be used when calling differentially expressed features.
@@ -99,7 +99,7 @@ qiime tools import --input-path selex.hdf5 --type FeatureTable[Frequency] --inpu
 
 # conds is title of column in metadata to be used as experimental conditions
 # this is the column used to decide which group each sample is in.
-qiime aldex2 aldex2 --i-table selex-table.qza --m-metadata-file selex_metadata.txt --p-condition conds --output-dir aldex_output
+qiime aldex2 aldex2 --i-table selex-table.qza --m-metadata-file selex_metadata.txt --m-metadata-column conds --output-dir aldex_output
 
 # p is effect plot or MA plot. currently only effect plot is available.
 qiime aldex2 effect-plot --i-table aldex_output/differentials.qza --p-type effect --o-visualization selex_effect

--- a/tutorial.md
+++ b/tutorial.md
@@ -115,7 +115,7 @@ This should generate several effect plots. To extract the differentially abundan
 ```
 qiime aldex2 extract-differences --i-table aldex_output/differentials.qza --o-differentials aldex_output/selex_significant_features --p-sig-threshold 0.1 --p-effect-threshold 0 --p-difference-threshold 0
 
-qiime tools extract --input-pathaldex_output/selex_significant_features.qza --output-path differentially-expressed-features
+qiime tools extract --input-path aldex_output/selex_significant_features.qza --output-path differentially-expressed-features
 ```
 
 Voila!


### PR DESCRIPTION
- Trimming down unused code
- Explicitly restrict some of the parameters used for `qiime aldex2 aldex2` -- note that this necessitated changing `--p-condition` to `--m-metadata-column`, but it has some nice benefits (as discussed in the dab3cce commit message)

This should close #5 (cc @mortonjt). Also, unrelated, but I'm pretty sure that we can close #1 at this point (now that Q2 2019.7 has been released).

One wart here is that the automatic tests fail. However: they already fail on just the code in ggloor/q2-aldex2, on the same line that they fail in this fork. (The [`pearsonr()`](https://github.com/ggloor/q2-aldex2/blob/master/q2_aldex2/tests/test_method.py#L141) line in `test_method.py` is where things break down -- it looks like `diff.values.ravel()` has a different length than `ground_truth.categorical.values.ravel()`).

Anyway, hope this all helps! It's really exciting to have these methods accessible through QIIME 2 :)